### PR TITLE
GitHub/Actions: Use a matrix strategy in the workflow for Ubuntu

### DIFF
--- a/.github/workflows/ubuntu_clean_meson_build.yml
+++ b/.github/workflows/ubuntu_clean_meson_build.yml
@@ -9,7 +9,10 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-18.04, ubuntu-20.04, ubuntu-22.04 ]
 
     steps:
     - uses: actions/checkout@v3

--- a/packaging/nnstreamer.spec
+++ b/packaging/nnstreamer.spec
@@ -22,7 +22,7 @@
 %define		tensorflow_support 0
 %define		tensorflow_lite_support	1
 %define		tensorflow2_lite_support 1
-%define		armnn_support 1
+%define		armnn_support 0
 %define		vivante_support 0
 %define		flatbuf_support 1
 %define		protobuf_support 1


### PR DESCRIPTION
As 'ubuntu-latest' is currently migrating from 20.04 to 22.04 [1], this patch uses a matrix strategy in our CI/CD workflow for Ubuntu.

[1] https://github.com/actions/runner-images#ongoing-migrations

Signed-off-by: Wook Song <wook16.song@samsung.com>